### PR TITLE
9 fix pagent wildcard definition for dg

### DIFF
--- a/files/pagttls.conf.j2
+++ b/files/pagttls.conf.j2
@@ -50,10 +50,19 @@ TTLSGroupAction  StunnelGroup
 {
   TTLSEnabled                       On
 }
+IpAddrGroup DataGateOCP
+{
+{% for item in dg2IPs %}
+  IpAddr
+  {
+    Addr {{ item }}
+  }
+{% endfor %}
+}
 TTLSRule StunnelDWP1Sim148
 {
-  REMOTEPORTRANGE                   1-20000
-  RemoteAddr                        0.0.0.0/0
+  RemotePortRange                   443
+  RemoteAddrGroupRef                DataGateOCP
   Direction                         Outbound
   TTLSGroupActionRef                StunnelGroup
   TTLSEnvironmentActionRef          StunnelClientEnvironment

--- a/setup_datagate.yaml
+++ b/setup_datagate.yaml
@@ -29,6 +29,14 @@
       shell:
         cmd: oc describe ingresscontroller default -n openshift-ingress-operator | grep domain | awk '{print $2;}' | tee {{ playbook_dir }}/cluster_domain.txt
       register: cluster_domain
+
+    - name: Install dnspython for community.general.dig query
+      dnf:
+        name: python3-dns
+        state: present
+      register: dnfresult
+      retries: 3
+      until: "dnfresult is not failed"
     
 - name: Setup the Data Gate parameters on z/OS
   hosts: zos
@@ -52,7 +60,7 @@
 
     - name: Set the dg2IPs fact (for use later)
       set_fact:
-        dg2IPs: "{{ query('community.general.dig', cluster_domain, qtype='A') }}"
+        dg2IPs: "{{ query('community.general.dig', cluster_domain.stdout, qtype='A') }}"
     - name: Allocate the user JCL dataset
       ibm.ibm_zos_core.zos_data_set:
         name: "{{ item }}"

--- a/setup_datagate.yaml
+++ b/setup_datagate.yaml
@@ -50,6 +50,9 @@
     LANG: "C"
   tasks:
 
+    - name: Set the dg2IPs fact (for use later)
+      set_fact:
+        dg2IPs: "{{ query('community.general.dig', cluster_domain, qtype='A') }}"
     - name: Allocate the user JCL dataset
       ibm.ibm_zos_core.zos_data_set:
         name: "{{ item }}"


### PR DESCRIPTION
Fixes #9 by adding an `IpAddrGroup` and the `Ref` to it.  Group is built from the IP addresses of the IBM Cloud ROKS load balancers for the cluster.

This modification of the DataGate rule frees up the definition to allow CDC to be added.