### PR TITLE
Peg community.general version

### DIFF
--- a/collections/requirements.yaml
+++ b/collections/requirements.yaml
@@ -1,5 +1,6 @@
 ---
 collections:
   - name: community.general
+    version: 9.5.13
   - name: ibm.ibm_zos_core
     version: 1.8.0


### PR DESCRIPTION
Fixes #13 by adding a specific version to the `community.general` entry in `requirements.yaml`.